### PR TITLE
feat(analyze-commits): analyze supporting file commits

### DIFF
--- a/src/options-transforms.js
+++ b/src/options-transforms.js
@@ -5,7 +5,11 @@ const commits = lensProp('commits');
 const nextRelease = lensProp('nextRelease');
 const version = lensProp('version');
 
-const mapCommits = fn => overA(commits, async commits => await fn(commits));
+const mapCommits = (fn, includeComplimentaryCommits) =>
+  overA(
+    commits,
+    async commits => await fn(commits, includeComplimentaryCommits)
+  );
 
 const mapNextReleaseVersion = overA(compose(nextRelease, version));
 


### PR DESCRIPTION
This update adds support for analyzing commits that impacted files _outside_ a package directory root. 

This adds value as one of the main reasons we use a monorepo is to share configuration files across packages that need to be distributed separately but ultimately share the same tooling configuration (ie. Webpack, Babel, Karma, etc). Many of our packages also share common utility functions that live in a commonly access `lib` folder at the root of the monorepo.

If we make changes to our Webpack process (ie hiding comments or suppressing console statements), we need to have a way for each plugin to recognize that change and apply a release to itself.

This new functionality ensures that changes to other packages **do not** get considered when analyzing changes for any one package.

Enabling this is done via the `release` config.