### PR TITLE
fix: wrap success and fail plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,34 @@ const generateNotes = wrapStep(
   }
 );
 
+const success = wrapStep(
+  'success',
+  compose(
+    logPluginVersion('success'),
+    withOnlyPackageCommits,
+    withOptionsTransforms([mapNextReleaseVersion(versionToGitTag)])
+  ),
+  {
+    wrapperName: 'semantic-release-monorepo',
+  }
+);
+
+const fail = wrapStep(
+  'fail',
+  compose(
+    logPluginVersion('fail'),
+    withOnlyPackageCommits,
+    withOptionsTransforms([mapNextReleaseVersion(versionToGitTag)])
+  ),
+  {
+    wrapperName: 'semantic-release-monorepo',
+  }
+);
+
 module.exports = {
   analyzeCommits,
   generateNotes,
+  success,
+  fail,
   tagFormat: readPkg.sync().name + '-v${version}',
 };


### PR DESCRIPTION
This should allow the posting of comments to work when using the `github` plugin.