### PR TITLE
feat: add full support for SEMANTIC_RELEASE_PACKAGE, non-JS packages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-const readPkg = require('read-pkg');
 const { compose } = require('ramda');
 const withOnlyPackageCommits = require('./only-package-commits');
 const versionToGitTag = require('./version-to-git-tag');
 const logPluginVersion = require('./log-plugin-version');
+const { getPackageInfoSync } = require('./package-info');
 const { wrapStep } = require('semantic-release-plugin-decorators');
 
 const {
@@ -59,5 +59,5 @@ module.exports = {
   generateNotes,
   success,
   fail,
-  tagFormat: readPkg.sync().name + '-v${version}',
+  tagFormat: getPackageInfoSync().name + '-v${version}',
 };

--- a/src/only-package-commits.js
+++ b/src/only-package-commits.js
@@ -1,10 +1,10 @@
 const { identity, memoizeWith, pipeP } = require('ramda');
 const pkgUp = require('pkg-up');
-const readPkg = require('read-pkg');
 const path = require('path');
 const pLimit = require('p-limit');
 const debug = require('debug')('semantic-release:monorepo');
 const { getCommitFiles, getRoot } = require('./git-utils');
+const { getPackageInfo } = require('./package-info');
 const { mapCommits } = require('./options-transforms');
 
 const memoizedGetCommitFiles = memoizeWith(identity, getCommitFiles);
@@ -13,7 +13,7 @@ const memoizedGetCommitFiles = memoizeWith(identity, getCommitFiles);
  * Get the normalized PACKAGE root path, relative to the git PROJECT root.
  */
 const getPackagePath = async () => {
-  const packagePath = await pkgUp();
+  const packagePath = await pkgUp() || './package.json';
   const gitRoot = await getRoot();
 
   return path.relative(gitRoot, path.resolve(packagePath, '..'));
@@ -68,7 +68,7 @@ const tapA = fn => async x => {
 };
 
 const logFilteredCommitCount = logger => async ({ commits }) => {
-  const { name } = await readPkg();
+  const { name } = await getPackageInfo();
 
   logger.log(
     'Found %s commits for package %s since last release',

--- a/src/package-info.js
+++ b/src/package-info.js
@@ -1,0 +1,14 @@
+const readPkg = require('read-pkg');
+
+const getPackageInfo = async () => ({
+  name: process.env.SEMANTIC_RELEASE_PACKAGE || (await readPkg()).name,
+});
+
+const getPackageInfoSync = () => ({
+  name: process.env.SEMANTIC_RELEASE_PACKAGE || readPkg.sync().name,
+});
+
+module.exports = {
+  getPackageInfo,
+  getPackageInfoSync,
+};

--- a/src/version-to-git-tag.js
+++ b/src/version-to-git-tag.js
@@ -1,10 +1,10 @@
-const readPkg = require('read-pkg');
+const { getPackageInfo } = require('./package-info')
 
 module.exports = async version => {
   if (!version) {
     return null;
   }
 
-  const { name } = await readPkg();
+  const name = (await getPackageInfo()).name;
   return `${name}-v${version}`;
 };


### PR DESCRIPTION
This change removes the hard dependency on `read-pkg`, falling back on `SEMANTIC_RELEASE_PACKAGE` where appropriate. This allows semantic-release-monorepo to manage projects which do not have `package.json` files, such as projects written in other languages.

BREAKING CHANGE: This can cause the package to be published under a different name in cases where `SEMANTIC_RELEASE_PACKAGE` was accidentally set, or was set to manage a different plugin's behavior.