### PR TITLE
fix: move git-utils deps from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,23 +18,24 @@
   "dependencies": {
     "debug": "^3.1.0",
     "execa": "^0.8.0",
-    "p-limit": "^1.2.0",
-    "pkg-up": "^2.0.0",
-    "ramda": "^0.25.0",
-    "read-pkg": "^5.0.0",
-    "semantic-release-plugin-decorators": "^3.0.0"
-  },
-  "devDependencies": {
     "file-url": "^3.0.0",
     "fs-extra": "^10.0.1",
     "get-stream": "^6.0.1",
     "git-log-parser": "^1.2.0",
+    "p-each-series": "^2.1.0",
+    "p-limit": "^1.2.0",
+    "pkg-up": "^2.0.0",
+    "ramda": "^0.25.0",
+    "read-pkg": "^5.0.0",
+    "semantic-release-plugin-decorators": "^3.0.0",
+    "tempy": "1.0.1"
+  },
+  "devDependencies": {
     "husky": "^4.2.1",
     "jest": "^25.1.0",
     "lint-staged": "^10.0.7",
     "p-each-series": "^2.1.0",
-    "prettier": "^1.19.1",
-    "tempy": "1.0.1"
+    "prettier": "^1.19.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This change moves various runtime dependencies of `git-utils.js` out from `devDependencies` and into `dependencies`. This helps ensure the plugin works correctly when installed globally.