### PR TITLE
fix: correctly import withOnlyPackageCommits

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const readPkg = require('read-pkg');
 const { compose } = require('ramda');
-const withOnlyPackageCommits = require('./only-package-commits');
+const { withOnlyPackageCommits } = require('./only-package-commits');
 const versionToGitTag = require('./version-to-git-tag');
 const logPluginVersion = require('./log-plugin-version');
 const { wrapStep } = require('semantic-release-plugin-decorators');


### PR DESCRIPTION
Commit 8c27b61d9fde57f1118274afa0fae6b998c8d192 updated `src/only-package-commits.js` to export all methods, instead of a default method, to ease testing. The import of this package in `index.js` was never updated. This causes a crash in Ramda's `compose()`, which was previously passed a function, but is currently passed an object instead.

This change updates the import to destructure the `withOnlyPackageCommits` function, ensuring the plugin works correctly.

