### PR TITLE
feat: provide an option to override separator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,5 +59,7 @@ module.exports = {
   generateNotes,
   success,
   fail,
-  tagFormat: readPkg.sync().name + '-v${version}',
+  separator: '-',
+  tagFormat: mapNextReleaseVersion(versionToGitTag, '${separator}').nextRelease
+    .version,
 };

--- a/src/version-to-git-tag.js
+++ b/src/version-to-git-tag.js
@@ -1,10 +1,9 @@
 const readPkg = require('read-pkg');
 
-module.exports = async version => {
+module.exports = async (version, separator = '-') => {
   if (!version) {
     return null;
   }
-
   const { name } = await readPkg();
-  return `${name}-v${version}`;
+  return `${name}${separator}v${version}`;
 };

--- a/src/version-to-git-tag.spec.js
+++ b/src/version-to-git-tag.spec.js
@@ -8,5 +8,16 @@ describe('#versionToGitTag', () => {
       expect(await versionToGitTag(null)).toBe(null);
       done();
     });
-  });
+  }),
+    describe('if passed a truly version', () => {
+      it('returns a correct version', async done => {
+        expect(await versionToGitTag('1.2.3')).toBe(
+          'semantic-release-monorepo-v1.2.3'
+        );
+        expect(await versionToGitTag('1.2.3', '/')).toBe(
+          'semantic-release-monorepo/v1.2.3'
+        );
+        done();
+      });
+    });
 });


### PR DESCRIPTION
Hello,

I need to be able to override a separator to release golang packages
I've found https://github.com/pmowrer/semantic-release-monorepo/issues/103 explaining issues about same behaviour and also about the workaround https://github.com/pmowrer/semantic-release-monorepo/issues/33

Well, I don't know if what i am doing is fine and also i don't know how to locally test the change.
Open to feedback and help on that
Thanks