### PR TITLE
fix: module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": ">=20"
+    "semantic-release": ">=22.0.7"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Plugins for `semantic-release` allowing it to be used with a monorepo.",
   "main": "src/index.js",
+  "type": "module",
   "files": [
     "src"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -55,5 +55,4 @@ const fail = wrapStep(
 
 const tagFormat = `${readPkg.sync().name}-v\${version}`;
 
-//TODO Change to esm export when https://github.com/semantic-release/semantic-release/pull/3037 is merged
-module.exports = { analyzeCommits, generateNotes, success, fail, tagFormat };
+export { analyzeCommits, generateNotes, success, fail, tagFormat };


### PR DESCRIPTION
The current version 8.0.0 does not work in an ESM environment:
- type is not set to `module` in package.json
- `src/index.js` does not export module style (it can, now that  https://github.com/semantic-release/semantic-release/pull/3037 is closed9