### PR TITLE
fix: fix undefined '__dirname' (in ES module) for debug option

### DIFF
--- a/src/log-plugin-version.js
+++ b/src/log-plugin-version.js
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import readPkg from 'read-pkg';
 import createDebug from 'debug';
 
@@ -6,6 +7,7 @@ const debug = createDebug('semantic-release:monorepo');
 
 const logPluginVersion = type => plugin => async (pluginConfig, config) => {
   if (config.options.debug) {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const { version } = await readPkg(resolve(__dirname, '../'));
     debug('Running %o version %o', type, version);
   }


### PR DESCRIPTION
Hi,

`__dirname` global var is not available in ES module: https://nodejs.org/docs/latest-v18.x/api/esm.html#no-__filename-or-__dirname

This issue is causing the `debug` mode to be failing, and this MR is fixing it.

Solution inspired from: https://stackoverflow.com/a/50052194