### PR TITLE
docs: fix script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run `semantic-release` in an **individual monorepo package** and apply `semantic
 On the command line:
 
 ```bash
-$ npm run semantic-release -e semantic-release-monorepo
+$ npx semantic-release -e semantic-release-monorepo
 ```
 
 Or in the [release config](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration-file):


### PR DESCRIPTION
Change erroneous example to run `semantic-release` via CLI from `npm run` to `npx`.